### PR TITLE
Parse Tree Display Improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,9 @@
       #bottomSection {
         display: flex;
         flex: 1;
+        overflow: auto;
+        flex-basis: auto;
+        min-height: max-content;
       }
 
       #bottomSection .overlay {
@@ -141,7 +144,6 @@
         display: flex;
         flex-direction: column;
         flex: 1;
-        overflow: hidden;
       }
 
       #grammarContainer,

--- a/public/style/parseTree.css
+++ b/public/style/parseTree.css
@@ -159,7 +159,7 @@
   color: #aaa;
 }
 .pexpr[hidden] {
-  visibility: hidden;
+  display: none;
 }
 .pexpr.unlabeled > .self .label {
   display: none;


### PR DESCRIPTION
- Use `display: none` to remove non-displayed pexpr nodes from DOM (better performance & the hidden parse nodes take up no screen space)
- Modified CSS for bottom pane
  - Preserved behavior where pane cannot be shrunk smaller than displayed parse tree
  - Added scrolling (x & y directions) when parse tree's height exceeds available screen size

I recently wrote a grammar for C in Ohm. The editor is wonderful, but I ran across a couple of annoyances while using it. The first was that I could not scroll down when a parse tree exceeded the size of the bottom pane. Since C can have quite large parse trees, this was problematic. Second, while stepping through a parse, I noticed a bunch of extra whitespace at the bottom of the pane below the current parse node. This was due to `visibility: hidden`, which only hides a node but doesn't remove it from the DOM.

I made a few simple changes to the CSS (summarized at the top), and now scrolling works while also not shrinking the bottom pane smaller than the maximum content height. I tested these changes in Chromium & Firefox.

(I still have one more that requires a more in-depth examination: namely, traversing deeply nested left-recursive productions creates an exponential number of parse nodes to visit. I'd prefer to display the memoization that Ohm is doing to move through LR nodes the way Ohm itself does. Once I get around to that, I'll make another PR.)